### PR TITLE
Added the csv download with filtering on the backend

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,4 +6,11 @@ class HomeController < ApplicationController
     @evaluations = Evaluation.evaluations_to_json params[:page] || 1
 
   end
+
+  def download
+    send_data Evaluation.to_csv(params[:ids]&.split(",")), {
+              type: "text/csv; charset=iso-8859-1; header=present",
+              disposition: "attachment",
+              filename: "protectedplanet-pame-#{Date.today}.csv" }
+  end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -74,40 +74,38 @@ class Evaluation < ApplicationRecord
 
     csv_string = CSV.generate do |csv_line|
 
-    evaluation_columns = Evaluation.new.attributes.keys
-    evaluation_columns << "evaluation_id"
+      evaluation_columns = Evaluation.new.attributes.keys
+      evaluation_columns << "evaluation_id"
 
-    excluded_attributes = ["created_at", "updated_at", "id", "site_id", "source_id"]
+      excluded_attributes = ["created_at", "updated_at", "id", "site_id", "source_id"]
 
-    evaluation_columns.delete_if { |k, v| excluded_attributes.include? k }
+      evaluation_columns.delete_if { |k, v| excluded_attributes.include? k }
 
-    additional_columns = ["wpda_id", "iso3", "name", "designation", "source_data_title", "source_resp_party", "source_year", "source_language"]
-    evaluation_columns << additional_columns.map{ |e| "#{e}" }
+      additional_columns = ["wpda_id", "iso3", "name", "designation", "source_data_title", "source_resp_party", "source_year", "source_language"]
+      evaluation_columns << additional_columns.map{ |e| "#{e}" }
 
-    csv_line << evaluation_columns.flatten
+      csv_line << evaluation_columns.flatten
 
-    evaluations = Evaluation.where(id: ids).order(id: :asc)
+      evaluations = Evaluation.where(id: ids).order(id: :asc)
 
-    evaluations.to_a.each do |evaluation|
-      evaluation_attributes = evaluation.attributes
-      evaluation_attributes.delete_if { |k, v| excluded_attributes.include? k }
+      evaluations.to_a.each do |evaluation|
+        evaluation_attributes = evaluation.attributes
+        evaluation_attributes.delete_if { |k, v| excluded_attributes.include? k }
 
-      evaluation_attributes["evaluation_id"] = evaluation.id
-      evaluation_attributes["wdpa_id"] = evaluation.site.wdpa_id
-      evaluation_attributes["iso3"] = evaluation.site.countries.pluck(:iso3).uniq.join(',').to_s
-      evaluation_attributes["name"] = evaluation.site.name
-      evaluation_attributes["designation"] = evaluation.site.designation
-      evaluation_attributes["source_data_title"] = evaluation.source.data_title
-      evaluation_attributes["source_resp_party"] = evaluation.source.resp_party
-      evaluation_attributes["source_year"] = evaluation.source.year
-      evaluation_attributes["source_language"] = evaluation.source.language
+        evaluation_attributes["evaluation_id"] = evaluation.id
+        evaluation_attributes["wdpa_id"] = evaluation.site.wdpa_id
+        evaluation_attributes["iso3"] = evaluation.site.countries.pluck(:iso3).uniq.join(',').to_s
+        evaluation_attributes["name"] = evaluation.site.name
+        evaluation_attributes["designation"] = evaluation.site.designation
+        evaluation_attributes["source_data_title"] = evaluation.source.data_title
+        evaluation_attributes["source_resp_party"] = evaluation.source.resp_party
+        evaluation_attributes["source_year"] = evaluation.source.year
+        evaluation_attributes["source_language"] = evaluation.source.language
 
-      evaluation_attributes = evaluation_attributes.values.map{ |e| "#{e}" }
-      csv_line << evaluation_attributes
+        evaluation_attributes = evaluation_attributes.values.map{ |e| "#{e}" }
+        csv_line << evaluation_attributes
+      end
     end
-  end
-
-  csv_string
-
+    csv_string
   end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class Evaluation < ApplicationRecord
   belongs_to :site
   belongs_to :source
@@ -79,17 +81,10 @@ class Evaluation < ApplicationRecord
 
     evaluation_columns.delete_if { |k, v| excluded_attributes.include? k }
 
-    evaluation_columns << "wpda_id"
-    evaluation_columns << "iso3"
-    evaluation_columns << "name"
-    evaluation_columns << "designation"
-    evaluation_columns << "source_data_title"
-    evaluation_columns << "source_resp_party"
-    evaluation_columns << "source_year"
-    evaluation_columns << "source_language"
+    additional_columns = ["wpda_id", "iso3", "name", "designation", "source_data_title", "source_resp_party", "source_year", "source_language"]
+    evaluation_columns << additional_columns
 
     csv << evaluation_columns.join(',')
-    csv << "\r\n"
 
     evaluations = Evaluation.where(id: ids).order(id: :asc)
 
@@ -109,10 +104,9 @@ class Evaluation < ApplicationRecord
 
       evaluation_attributes = evaluation_attributes.values.map{ |e| "\"#{e}\"" }
       csv << evaluation_attributes.join(',').to_s
-      csv << "\r\n"
     end
 
-  csv
+  csv.to_csv
 
   end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -72,7 +72,7 @@ class Evaluation < ApplicationRecord
 
   def self.to_csv(ids = [])
 
-    csv = ''
+    csv_string = CSV.generate do |csv_line|
 
     evaluation_columns = Evaluation.new.attributes.keys
     evaluation_columns << "evaluation_id"
@@ -82,9 +82,9 @@ class Evaluation < ApplicationRecord
     evaluation_columns.delete_if { |k, v| excluded_attributes.include? k }
 
     additional_columns = ["wpda_id", "iso3", "name", "designation", "source_data_title", "source_resp_party", "source_year", "source_language"]
-    evaluation_columns << additional_columns
+    evaluation_columns << additional_columns.map{ |e| "#{e}" }
 
-    csv << evaluation_columns.join(',')
+    csv_line << evaluation_columns.flatten
 
     evaluations = Evaluation.where(id: ids).order(id: :asc)
 
@@ -102,11 +102,12 @@ class Evaluation < ApplicationRecord
       evaluation_attributes["source_year"] = evaluation.source.year
       evaluation_attributes["source_language"] = evaluation.source.language
 
-      evaluation_attributes = evaluation_attributes.values.map{ |e| "\"#{e}\"" }
-      csv << evaluation_attributes.join(',').to_s
+      evaluation_attributes = evaluation_attributes.values.map{ |e| "#{e}" }
+      csv_line << evaluation_attributes
     end
+  end
 
-  csv.to_csv
+  csv_string
 
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
 
   get '/', to: 'home#index'
   post '/download', to: 'home#download'
-  get '/download', to: 'home#download'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   get '/', to: 'home#index'
   post '/download', to: 'home#download'
+  get '/download', to: 'home#download'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Initial support for CSV downloads when provided with a list of ids, locally, you would do something like a POST request to: `http://localhost:3000/download?ids=1,2`

Please note that the order of the columns in the generated CSV are different to the order in the initial CSV we import with the rake task. If the order needs to change I am happy to do that.